### PR TITLE
fix setup, to clarify .env usage

### DIFF
--- a/setup/SETUP.md
+++ b/setup/SETUP.md
@@ -10,7 +10,10 @@
 
 ## I. Setup the configuration file
 
-The `Makefile` gets configuration information like usernames and secrets from a file called `.env`.
+The `Makefile` gets configuration information like usernames and secrets from a file called `.env` or `.env.dev`.
+It decides which to use based on the `ENV` environment variable.
+
+If you don't have one of these files, you can create one from the template:
 
 We've included an empty template file, `.env.example`. Copy it to `.env` with:
 
@@ -203,6 +206,7 @@ Name them `fsdl` and `ask-fsdl`, respectively.
 #### d - Create a user and password
 
 See instructions [here](https://www.youtube.com/watch?v=5-hybmPlZ_U&t=11s).
+Copy the password to the your active `.env`file ( `.env` and/or  `.env.dev`)
 
 #### e - Enable network access
 
@@ -230,10 +234,18 @@ in the "Connect" tab of the MongoDB Atlas dashboard:
 
 ![connect-3](./mongodb/connect-3.png)
 
+> **Note:** This is an important note.
+Copy the connection string it should look like this 
+mongodb+srv://the_name_you_picked_for_the_db:<password>@fsdl.chjrrhb.mongodb.net/
+Then go to the active  `.env`file ( `.env` and/or  `.env.dev`) and add the values.
+For the above example it should be:
+MONGODB_URI=fsdl.chjrrhb.mongodb.net
+MONGODB_USER=the_name_you_picked_for_the_db
+
 ### 5 - Push all of the configuration information to Modal
 
 For the application to run,
-it needs the information in the `.env` file.
+it needs the information in the active `.env` file.
 
 We push that information to Modal with
 


### PR DESCRIPTION
I had issues with connecting to mongodb.
In the end, it was a collection of wrong assumptions I had that made me miss some information. 
So this PR tried to make this info hard to miss.

My wrong assumptions were:
1) .env is the only active file (while there is magic in the background to update it per the active configuration).
2) the mongo_db_uri might include the ending "/". The term mongodb_uri kind of confused me - what exactly does it include? 

Some other wrong assumptions I had that might worth fixing are:
1) that the setup is "more mature" so I came with a user state of mind, not a developer 
2) as a result I treated modal as a black box while trying to install it the first time, in the end, it is a Python library for the cloud that you can play with its code for debugging as well.
3) The explanation today is not mature enough to hold the 2 different configurations for a newcomer. so 
Either 
- The setup installation should be dealing with only one setup, probably production because as a developer you might be tempted to start the dev env. 
Or 
- A  detailed explanation of the difference between dev and production should be in the prefix, as well as the difference between running the modal locally or in the cloud (and maybe the difference in the requirement.txt and other differences if they exist).   